### PR TITLE
feat(user): implement user subdomain with hexagonal architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+.idea

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,8 +28,16 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<org.mapstruct.version>1.6.3</org.mapstruct.version>
 	</properties>
 	<dependencies>
+
+    	<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -114,6 +122,24 @@
 
 	<build>
 		<plugins>
+			<plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-compiler-plugin</artifactId>
+            	<version>3.8.1</version>
+				<configuration>
+					<source>1.8</source> <!-- depending on your project -->
+					<target>1.8</target> <!-- depending on your project -->
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+						<!-- other annotation processors -->
+					</annotationProcessorPaths>
+				</configuration>
+        	</plugin>
+		
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.samir.saas</groupId>
 	<artifactId>backend</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>backend</name>
 	<description>Demo project for Spring Boot</description>
-	<url/>
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>21</java.version>
@@ -32,7 +33,7 @@
 	</properties>
 	<dependencies>
 
-    	<dependency>
+		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
 			<version>${org.mapstruct.version}</version>
@@ -123,31 +124,23 @@
 	<build>
 		<plugins>
 			<plugin>
-            	<groupId>org.apache.maven.plugins</groupId>
-            	<artifactId>maven-compiler-plugin</artifactId>
-            	<version>3.8.1</version>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source> <!-- depending on your project -->
-					<target>1.8</target> <!-- depending on your project -->
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.mapstruct</groupId>
 							<artifactId>mapstruct-processor</artifactId>
 							<version>${org.mapstruct.version}</version>
 						</path>
-						<!-- other annotation processors -->
-					</annotationProcessorPaths>
-				</configuration>
-        	</plugin>
-		
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
 						</path>
 						<path>
 							<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/samir/saas/backend/user/domain/User.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/domain/User.java
@@ -1,0 +1,21 @@
+package com.samir.saas.backend.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    private UUID id;
+    private String email;
+    private String password;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/src/main/java/com/samir/saas/backend/user/domain/UserRepository.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/domain/UserRepository.java
@@ -1,0 +1,11 @@
+package com.samir.saas.backend.user.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+    User save(User user);
+    Optional<User> findById(UUID id);
+    Optional<User> findByEmail(String email);
+    void deleteById(UUID id);
+}

--- a/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserEntity.java
@@ -31,9 +31,12 @@ public class UserEntity {
 
     @PrePersist
     protected void onCreate() {
-        this.id = UUID.randomUUID();
-        this.createdAt = Instant.now();
-        this.updatedAt = Instant.now();
+        if (this.id == null) {
+            this.id = UUID.randomUUID();
+        }
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
     }
 
     @PreUpdate

--- a/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserEntity.java
@@ -1,0 +1,43 @@
+package com.samir.saas.backend.user.infra.persistence;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserJpaRepository.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.samir.saas.backend.user.infra.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, UUID> {
+    Optional<UserEntity> findByEmail(String email);
+}

--- a/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserMapper.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserMapper.java
@@ -1,0 +1,14 @@
+package com.samir.saas.backend.user.infra.persistence;
+
+import com.samir.saas.backend.user.domain.User;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    UserEntity toEntity(User user);
+    User toDomain(UserEntity entity);
+}

--- a/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/com/samir/saas/backend/user/infra/persistence/UserRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.samir.saas.backend.user.infra.persistence;
+
+import com.samir.saas.backend.user.domain.User;
+import com.samir.saas.backend.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+    private final UserMapper userMapper;
+
+    @Override
+    public User save(User user) {
+        UserEntity saved = userJpaRepository.save(userMapper.toEntity(user));
+        return userMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return userJpaRepository.findById(id).map(userMapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userJpaRepository.findByEmail(email).map(userMapper::toDomain);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        userJpaRepository.deleteById(id);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,8 +9,9 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
+    data:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/db/migration/V1__create_user_table.sql
+++ b/backend/src/main/resources/db/migration/V1__create_user_table.sql
@@ -1,0 +1,8 @@
+-- V1__create_user_table
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);

--- a/backend/src/test/java/com/samir/saas/backend/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/samir/saas/backend/TestcontainersConfiguration.java
@@ -7,12 +7,12 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration {
+public class TestcontainersConfiguration {
 
-	@Bean
-	@ServiceConnection
-	PostgreSQLContainer<?> postgresContainer() {
-		return new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"));
-	}
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2"));
+    }
 
 }

--- a/backend/src/test/java/com/samir/saas/backend/user/UserRepositoryImplTest.java
+++ b/backend/src/test/java/com/samir/saas/backend/user/UserRepositoryImplTest.java
@@ -1,0 +1,52 @@
+package com.samir.saas.backend.user;
+
+import com.samir.saas.backend.user.domain.User;
+import com.samir.saas.backend.user.domain.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import com.samir.saas.backend.TestcontainersConfiguration;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+@Transactional
+@Testcontainers
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class UserRepositoryImplTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void shouldSaveAndRetrieveUser() {
+        var id = UUID.randomUUID();
+        String email = "test@example.com";
+        String password = "secure";
+        Instant now = Instant.now();
+
+        User user = User.builder()
+                .id(id)
+                .email(email)
+                .password(password)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        userRepository.save(user);
+        System.out.println("User saved: " + user);
+
+        Optional<User> found = userRepository.findByEmail(email);
+
+        assertTrue(found.isPresent());
+        assertEquals(user.getId(), found.get().getId());
+        assertEquals(email, found.get().getEmail());
+        assertEquals(password, found.get().getPassword());
+    }
+}


### PR DESCRIPTION
This PR introduces the `user` subdomain following Hexagonal Architecture principles. It includes the domain entity, repository interfaces, and infrastructure-level persistence using Spring Data JPA and MapStruct.

### Key Changes

- ✅ `User` domain model
- ✅ JPA entity for persistence
- ✅ MapStruct mapper between domain and entity
- ✅ Repository adapter for PostgreSQL
- ✅ Flyway migration to create the `users` table
- ✅ Sample test to verify Flyway and DB connection

### Misc

- Fixed MapStruct + Lombok binding issues
- Pinned exact Postgres image version in Testcontainers


---

### Notes

This sets the foundation for user registration and authentication logic in the next PR.
